### PR TITLE
v5.0.1: add on:master tag after release and fix typo on the README

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,7 +5,9 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",
-    "@semantic-release/git",
+    ["@semantic-release/git", {
+      "releasedLabels": ["on:master", "released"]
+    }],
     "@semantic-release/github"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ This is because is not unusual **for me** to write `.sh` or extension-less files
 
 #### [`array-bracket-newline`](https://eslint.org/docs/rules/array-bracket-newline)
 
-> `off` -> `['error', 'consistent']
+> `off` -> `['error', 'consistent']`
 
 Consistency.
 


### PR DESCRIPTION
- I still can't automatically remove `on:next` from the PRs after a release, but I can add `on:master`. I'll build a custom action in the future for `on:next`.
- I fixed a typo on the `README` as an excuse for an extra release.